### PR TITLE
Bug-fix for ellipsoid generation.

### DIFF
--- a/srfi/sphere.scm
+++ b/srfi/sphere.scm
@@ -22,7 +22,7 @@
   (define gaussg-vec
     (vector-map
       (lambda (size)
-        (make-normal-generator 0.0 (sqrt size)))
+        (make-normal-generator 0.0 size))
       dim-sizes))
   ; Banach l2-norm aka root-mean-square distance.
   (define (l2-norm VEC)


### PR DESCRIPTION
A stray sqrt appears to have entered into the code. Removing this
fixes the issue reported in the email chain
"Converting spherical to elliptical distribution"
on srfi-194@srfi.schemers.org