### PR TITLE
Working ellipsoid generator plus unit test

### DIFF
--- a/ellipsoid-test.scm
+++ b/ellipsoid-test.scm
@@ -33,14 +33,14 @@
 ; Vector subtraction
 ; Example usage: (vector-diff '#( 2 3) '#(0.5 0.7))
 (define (vector-sub a b)
-   (vector-map (lambda (idx ea eb) (- ea eb)) a b))
+	(vector-map (lambda (idx ea eb) (- ea eb)) a b))
 
 ; Newton differences - compute the difference between neighboring
 ; points. Assumes `pts` is a list of vectors.  Should be called with
 ; `rv` set to the null list. (tail-recursive helper)
 (define (delta pts rv)
-   (if (null? (cdr pts)) (reverse! rv)
-      (delta (cdr pts) (cons (vector-diff (car pts) (cadr pts)) rv))))
+	(if (null? (cdr pts)) (reverse! rv)
+		(delta (cdr pts) (cons (vector-diff (car pts) (cadr pts)) rv))))
 
 ; Compute sum of a list of numbers
 (define (sum lst) (fold (lambda (x sum) (+ sum x)) 0 lst))
@@ -59,37 +59,37 @@
 
 ; factorial
 (define (fact n rv)
-   (if (zero? n) rv (fact (- n 1) (* n rv))))
+	(if (zero? n) rv (fact (- n 1) (* n rv))))
 
 ; Double factorial
 ; https://en.wikipedia.org/wiki/Double_factorial
 (define (double-fact n rv)
-   (if (<= n 0) rv (double-fact (- n 2) (* n rv))))
+	(if (<= n 0) rv (double-fact (- n 2) (* n rv))))
 
 ; Complete elliptic integral per wikipedia, see the Ivorty& Bessel
 ; expansion. Here `a` and `b` are the axes.
 ; https://en.wikipedia.org/wiki/Ellipse
 (define (complete-elliptic a b)
-   (define rh (/ (- a b) (+ a b)))
-   (define h (* rh rh))
+	(define rh (/ (- a b) (+ a b)))
+	(define h (* rh rh))
 
 	(define precision 1e-10)
 
-   (define (ivory term n twon hn fact-n dfact-n sum)
-      (if (< term precision) (+ sum term)
-         ; (format #t "yo n= ~A term=~A 2^n=~A h^n=~A n!=~A n!!=~A sum=~A\n"
-         ; n term twon hn fact-n dfact-n sum)
-         (ivory
-            (/ (* dfact-n dfact-n hn) (* twon twon fact-n fact-n))
-            (+ n 1)
-            (* 2 twon)
-            (* h hn)
-            (* (+ n 1) fact-n)
-            (* (- (* 2 n) 1) dfact-n)
-            (+ term sum))))
+	(define (ivory term n twon hn fact-n dfact-n sum)
+		(if (< term precision) (+ sum term)
+			; (format #t "yo n= ~A term=~A 2^n=~A h^n=~A n!=~A n!!=~A sum=~A\n"
+			; n term twon hn fact-n dfact-n sum)
+			(ivory
+				(/ (* dfact-n dfact-n hn) (* twon twon fact-n fact-n))
+				(+ n 1)
+				(* 2 twon)
+				(* h hn)
+				(* (+ n 1) fact-n)
+				(* (- (* 2 n) 1) dfact-n)
+				(+ term sum))))
 
-   (* pi (+ a b) (+ 1 (/ h 4)
-      (ivory (/ (* h h) 64) 3 8 (* h h h) 6 3 0.0))))
+	(* pi (+ a b) (+ 1 (/ h 4)
+		(ivory (/ (* h h) 64) 3 8 (* h h h) 6 3 0.0))))
 
 ; -----------------------------------------------------------
 

--- a/ellipsoid-test.scm
+++ b/ellipsoid-test.scm
@@ -1,0 +1,55 @@
+; 
+; ellipsoid-test.scm
+;
+; Verify that the diistribution of points on the surface of an
+; ellipsoid is uniform.
+;
+; Test proceeds by taking 2-D slices through the ellipsoid, and
+; verifying uniformity on that slice. Thus, the core test is for
+; ellipses.
+;
+
+; Sort a list of 2D vectors of floats into clock-wise order.
+; Assumes that `pts` is a list of 2D vectors of floats.
+(define (clockwise pts)
+	(sort pts (lambda (a b)
+		(if (and (< 0 (vector-ref a 1)) (< 0 (vector-ref b 1)))
+			(< (vector-ref b 0) (vector-ref a 0))
+			(if (and (< (vector-ref a 1) 0) (< (vector-ref b 1) 0))
+				(< (vector-ref a 0) (vector-ref b 0))
+				(< (vector-ref b 1) (vector-ref a 1)))))))
+
+; Verfiy that the routine above is not broken.
+; Returns #t if it is OK.
+(define (test-clockwise)
+	(define  clock (list
+		'#(1 1e-3) '#(0.8 0.2) '#(0.2 0.8)
+		'#(0 1) '#(-0.2 0.8) '#(-0.8 0.2) '#(-1 1e-3)
+		'#(-1 -1e-3) '#(-0.8 -0.2) '#(-0.2 -0.8)
+		'#(0 -1) '#(0.2 -0.8) '#(0.8 -0.2) '#(1 -1e-3)))
+
+	(equal? (clockwise clock) clock))
+
+; Vector subtraction
+; Example usage: (vector-diff '#( 2 3) '#(0.5 0.7))
+(define (vector-sub a b)
+   (vector-map (lambda (idx ea eb) (- ea eb)) a b))
+
+; Newton differences - compute the difference between neighboring
+; points. Assumes `pts` is a list of vectors.  Should be called with
+; `rv` set to the null list. (tail-recursive helper) 
+(define (delta pts rv)
+   (if (null? (cdr pts)) (reverse! rv)
+      (delta (cdr pts) (cons (vector-diff (car pts) (cadr pts)) rv))))
+
+; Assumes that `points` is a list of 2D vectors of floats.
+(define (verify-ellipse points)
+	; Place in sorted order.
+	(define ordered-points (clockwise points))
+
+	; Difference between neghboring points.
+	(define diffs (delta ordered-points '()))
+
+	; Compute the distances between neighboring points
+	(define dists (map l2-norm diffs))
+

--- a/ellipsoid-test.scm
+++ b/ellipsoid-test.scm
@@ -33,7 +33,7 @@
 ; Vector subtraction
 ; Example usage: (vector-diff '#( 2 3) '#(0.5 0.7))
 (define (vector-sub a b)
-	(vector-map (lambda (idx ea eb) (- ea eb)) a b))
+	(vector-map (lambda (ea eb) (- ea eb)) a b))
 
 ; Newton differences - compute the difference between neighboring
 ; points. Assumes `pts` is a list of vectors.  Should be called with
@@ -204,14 +204,14 @@
 
 		;; Take the slice off-center
 		(define diff
-			(vector-map (lambda (idx r s) (- r s)) point where))
+			(vector-map (lambda (r s) (- r s)) point where))
 
 		;; Return #t if the point is in the slice
 		(define (ok vec)
-			(vector-fold (lambda (idx pass coord)
+			(vector-fold (lambda (pass coord idx)
 				(or (< idx 2)
 					(and pass (< (- 0 thickness) coord) (< coord thickness))))
-				#t vec))
+				#t vec (iota (vector-length vec)) ))
 
 		; Test
 		(ok diff))

--- a/ellipsoid-test.scm
+++ b/ellipsoid-test.scm
@@ -155,10 +155,10 @@
 	(format #t "RMS error: ~A\n" rms)
 	(newline)
 
-;	(test-assert (< error 12))
-;	(test-assert (< 0 error))
-;	(test-assert (< 0.97 rms))
-;	(test-assert (< 1.03 rms))
+	(test-assert (< error 12))
+	(test-assert (< 0 error))
+	(test-assert (< 0.97 rms))
+	(test-assert (< 1.03 rms))
 )
 
 ; ------------------------------------------------------

--- a/ellipsoid-test.scm
+++ b/ellipsoid-test.scm
@@ -99,34 +99,30 @@
 	; Sum of the intervals
 	(define perimeter (sum dists))
 
-	; The smaller of two coords.
-	(define (least PNT)
-		(define x (abs (vector-ref PNT 0)))
-		(define y (abs (vector-ref PNT 1)))
-		(if (< x y) x y))
-
-	; The greater of two coords.
-	(define (greatest PNT)
-		(define x (abs (vector-ref PNT 0)))
-		(define y (abs (vector-ref PNT 1)))
-		(if (< x y) y x))
-
 	; Find major and minor axes
 	(define major
-		(fold (lambda (MAJ P)
-			(if (< MAJ (greatest P)) (greatest P)  MAJ))
-			points))
+		(fold (lambda (MAJ x)
+			(if (< MAJ x) x MAJ))
+			0
+			(map l2-norm points)))
+
 	(define minor
-		(fold (lambda (MIN P)
-			(if (< MIN (least P)) (least P)  MIN))
-			points))
+		(fold (lambda (MIN x)
+			(if (< MIN x) MIN x))
+			1.0e308
+			(map l2-norm points)))
 
 	; The expected perimiter
 	(define perim-exact (complete-elliptic major minor))
 
 	; The normalized difference of measured and expected perimeters
+	; Should almost always be less than ten, often less than two.
 	(define error
 		(abs (* (/ (- perimeter perim-exact) perim-exact) (length points))))
 
-	(format #t "Got ~A\n" error)
+	(format #t "Number of points: ~A\n" (length points))
+	(format #t "Measured perimeter: ~A\n" perimeter)
+	(format #t "Major and minor axes: ~A ~A\n" major minor)
+	(format #t "Expected perimeter: ~A\n" perim-exact)
+	(format #t "Relative error: ~A\n" error)
 )

--- a/srfi/sphere.scm
+++ b/srfi/sphere.scm
@@ -45,7 +45,7 @@
   ; Banach l2-norm of a vector
   (define (l2-norm VEC)
     (sqrt (vector-fold
-            (lambda (idx sum x) (+ sum (* x x)))
+            (lambda (sum x) (+ sum (* x x)))
             0
             VEC)))
 
@@ -53,22 +53,22 @@
   (define (sph)
     ; Sample a point
     (define point
-      (vector-map (lambda (idx gaussg) (gaussg)) gaussg-vec))
+      (vector-map (lambda (gaussg) (gaussg)) gaussg-vec))
     ; Project it to the unit sphere (make it unit length)
     (define norm (/ 1.0 (l2-norm point)))
-    (vector-map (lambda (idx x) (* x norm)) point))
+    (vector-map (lambda (x) (* x norm)) point))
 
   ; Distance from origin to the surface of the
   ; ellipsoid along direction RAY.
   (define (ellipsoid-dist RAY)
     (sqrt (vector-fold
-            (lambda (idx sum x a) (+ sum (/ (* x x) (* a a))))
+            (lambda (sum x a) (+ sum (/ (* x x) (* a a))))
             0 RAY axes)))
 
   ; Find the shortest axis.
   (define minor
     (vector-fold
-        (lambda (idx mino l) (if (< l mino) l mino))
+        (lambda (mino l) (if (< l mino) l mino))
         1e308 axes))
 
   ; Uniform generator [0,1)
@@ -87,7 +87,7 @@
   (lambda ()
   ; Find a good point, and rescale to ellipsoid.
     (vector-map
-         (lambda (idx x a) (* x a)) (sample) axes))
+         (lambda (x a) (* x a)) (sample) axes))
 )
 
 ; -----------------------------------------------

--- a/srfi/sphere.scm
+++ b/srfi/sphere.scm
@@ -7,45 +7,90 @@
 ; http://extremelearning.com.au/how-to-generate-uniformly-random-points-on-n-spheres-and-n-balls/
 ;
 
-
 ; make-sphere-generator N - return a generator of points uniformly
 ; distributed on an N-dimensional sphere.
 ; This implements the BoxMeuller algorithm, that is, of normalizing
 ; N+1 Gaussian random variables.
 (define (make-sphere-generator arg)
   (cond
-    ((integer? arg) (make-sphere-generator* (make-vector (+ 1 arg) 1.0)))
-    ((vector? arg) (make-sphere-generator* arg))
-    (else (error "expected argument to either be a number (dimension), or vector (axis length for the dimensions)"))))
+    ((integer? arg) (make-ellipsoid-generator* (make-vector (+ 1 arg) 1.0)))
+    (else (error "expected argument to be an integer dimension"))))
 
-(define (make-sphere-generator* dim-sizes)
+(define (make-ellipsoid-generator arg)
+  (cond
+    ((vector? arg) (make-ellipsoid-generator* arg))
+    (else (error "expected argument to be a vector of axis lengths"))))
+
+; -----------------------------------------------
+; Generator of points uniformly distributed on an N-dimensional ellipsoid.
+;
+; The `axes` should be a vector of floats, specifying the axes of the
+; ellipsoid. The algorithm used is an accept/reject sampling algo,
+; wherein the acceptance rate is proportional to the measure of a
+; surface element on the ellipsoid. The measure is straight-forward to
+; arrive at, and the 3D case is described by `mercio` in detail at
+; https://math.stackexchange.com/questions/973101/how-to-generate-points-uniformly-distributed-on-the-surface-of-an-ellipsoid
+;
+; Note that sampling means that performance goes as
+; O(B/A x C/A x D/A x ...) where `A` is the shorest axis,
+; and `B`, `C`, `D`, ... are the other axes. Maximum performance
+; achieved on spheres.
+;
+(define (make-ellipsoid-generator* axes)
+
+  ; A vector of normal gaussian generators
   (define gaussg-vec
-    (vector-map
-      (lambda (size)
-        (make-normal-generator 0.0 (sqrt size)))
-      dim-sizes))
-  ; Banach l2-norm aka root-mean-square distance.
+    (make-vector (vector-length axes) (make-normal-generator 0 1)))
+
+  ; Banach l2-norm of a vector
   (define (l2-norm VEC)
     (sqrt (vector-fold
-            (lambda (sum x l)
-              (+ sum (/ (* x x)
-                        (* l l)
-                        )))
+            (lambda (idx sum x) (+ sum (* x x)))
             0
-            VEC
-            dim-sizes)))
+            VEC)))
+
+  ; Generate one point on a sphere
+  (define (sph)
+    ; Sample a point
+    (define point
+      (vector-map (lambda (idx gaussg) (gaussg)) gaussg-vec))
+    ; Project it to the unit sphere (make it unit length)
+    (define norm (/ 1.0 (l2-norm point)))
+    (vector-map (lambda (idx x) (* x norm)) point))
+
+  ; Distance from origin to the surface of the
+  ; ellipsoid along direction RAY.
+  (define (ellipsoid-dist RAY)
+    (sqrt (vector-fold
+            (lambda (idx sum x a) (+ sum (/ (* x x) (* a a))))
+            0 RAY axes)))
+
+  ; Find the shortest axis.
+  (define minor
+    (vector-fold
+        (lambda (idx mino l) (if (< l mino) l mino))
+        1e308 axes))
+
+  ; Uniform generator [0,1)
+  (define uni (make-uniform-generator))
+
+  ; Return #t if the POINT can be kept; else must resample.
+  (define (keep POINT)
+    (< (uni) (* minor (ellipsoid-dist POINT))))
+
+  ; Sample until a good point is found. The returned sample is a
+  ; vector of unit length (we already normed up above).
+  (define (sample)
+    (define vect (sph))
+    (if (keep vect) vect (sample)))
 
   (lambda ()
-    (define vect
-      (vector-map
-        (lambda (gaussg)
-          (gaussg))
-        gaussg-vec))
-    (define norm (/ 1.0 (l2-norm vect)))
-    (vector-map (lambda (x)
-                  (* x norm))
-                vect)))
+  ; Find a good point, and rescale to ellipsoid.
+    (vector-map
+         (lambda (idx x a) (* x a)) (sample) axes))
+)
 
+; -----------------------------------------------
 ; make-ball-generator N - return a generator of points uniformly
 ; distributed inside an N-dimensional ball.
 ; This implements the Harman-Lacko-Voelker Dropped Coordinate method.


### PR DESCRIPTION
This implements a working ellipsoid generator plus a unit test for it.

One important note:
* This introduces a call `make-ellipsoid-generator` which unbundles the ellipsoid-part from the sphere part of things. This is incompatible with the current documentation, which lumps both under the same name. There are two solutions: either bundle things back together again, or "advertise" that ellipsoids are NOT just spheres.

I think I removed all guile-isms and scaffolding... but am not able to run this srfi as a whole, without my weird private hacks. 

I really wish to be done. :-)