### PR TITLE
Binomial random variables: use correct strean of random reals

### DIFF
--- a/srfi/194-impl.scm
+++ b/srfi/194-impl.scm
@@ -389,6 +389,7 @@
 
 
 ;;; Code for binomial random variable generation.
+;;; Written by Brad Lucier, lucier@math.purdue.edu
 
 ;;; binomial-geometric is somewhat classical, the
 ;;; "First waiting time algorithm" from page 525 of
@@ -515,8 +516,8 @@
                   (+ (* (+ (* 2. (/ a us)) b) u) c)))))
           (cond ((or (< k 0)
                      (< n k))
-                 (loop (random-real)
-                       (random-real)))
+                 (loop (rand-real-proc)
+                       (rand-real-proc)))
                 ((and (<= 0.07 us)
                       (<= v v_r))
                  k)
@@ -542,5 +543,5 @@
                                   (+ (stirling-tail k)
                                      (stirling-tail (- n k))))))
                        k
-                       (loop (random-real)
-                             (random-real)))))))))))
+                       (loop (rand-real-proc)
+                             (rand-real-proc)))))))))))


### PR DESCRIPTION
srfi/194-impl.scm:

1.  Use stream of real random variables generated from (current-random-source), not the initial default random source.

2.  Add my name to the implementation so people can find me if they have problems.