### PR TITLE
 Rework ball and ellipsoid generators, add tests

### DIFF
--- a/sphere-test.scm
+++ b/sphere-test.scm
@@ -182,14 +182,14 @@
       ;; O(Delta^4) numerical integration
       ;; integrate f between t0 and t1 with N intervals
       (let* ((Delta (/ (- t1 t0) N))
-             (sum1 (do ((i 0 (fx+ i 1))
+             (sum1 (do ((i 0 (+ i 1))
                         (sum 0. (+ sum
                                    (f (+ t0 (* i Delta)))
-                                   (f (+ t0 (* (fx+ i 1) Delta))))))
-                       ((fx= i N) sum)))
-             (sum2 (do ((i 0 (fx+ i 1))
+                                   (f (+ t0 (* (+ i 1) Delta))))))
+                       ((= i N) sum)))
+             (sum2 (do ((i 0 (+ i 1))
                         (sum 0. (+ sum (f (+ t0 (* (+ i 0.5) Delta))))))
-                       ((fx= i N) sum))))
+                       ((= i N) sum))))
         (* Delta (/ (+ (* 4 sum2) sum1) 6))))
 
     (define p-right

--- a/sphere-test.scm
+++ b/sphere-test.scm
@@ -1,18 +1,19 @@
-; SPDX-FileCopyrightText: 2020 Arvydas Silanskas
-; SPDX-License-Identifier: MIT
-;
-; Take REPS samples from unit sphere, verify random distribution.
-;
-; This test checks that:
-; * Every sample has unit length, within numerical tolerance.
-; * The REPS samples are uniformly distributed.
-; * Rotations of the REPS samples are uniformly distributed.
+;;; SPDX-FileCopyrightText: 2020 Arvydas Silanskas
+;;; SPDX-FileCopyrightText: 2024 Bradley J Lucier
+;;; SPDX-License-Identifier: MIT
+;;;
+;;; Take REPS samples from unit sphere, verify random distribution.
+;;;
+;;; This test checks that:
+;;; * Every sample has unit length, within numerical tolerance.
+;;; * The REPS samples are uniformly distributed.
+;;; * Rotations of the REPS samples are uniformly distributed.
 (define (test-sphere sphereg dim-sizes REPS rotate?)
   (define random-int (random-source-make-integers (current-random-source)))
   (define random-real (random-source-make-reals (current-random-source)))
   (define N (- (vector-length dim-sizes) 1))
 
-  ; Fix list of samples
+  ;; Fix list of samples
   (define samples
     (generator->list (gtake sphereg REPS)))
 
@@ -24,8 +25,8 @@
             VEC
             dim-sizes)))
 
-  ; Rotate the j'th amnd k'th coordinates of a vector VEC
-  ; by cosine co and sine si
+  ;; Rotate the j'th amnd k'th coordinates of a vector VEC
+  ;; by cosine co and sine si
   (define (pair-rot VEC j k co si)
     (define oj (vector-ref VEC j))
     (define ok (vector-ref VEC k))
@@ -39,7 +40,7 @@
                (else (vector-ref VEC index))))
            (iota (vector-length VEC)))))
 
-  ; Apply a random rotation to a collection of vectors
+  ;; Apply a random rotation to a collection of vectors
   (define how-many-rots
     (if (< 10 N) 10 N))
 
@@ -57,10 +58,10 @@
         (arb-rot rvl)
         rvl))
 
-  ; Expect a vector approaching zero. That is, each individual
-  ; coordinate should be uniformly randomly distributed in the
-  ; interval [-1,1]. The sum of REPS samples of these should
-  ; converge to zero, within pi/2 sqrt(REPS).
+  ;; Expect a vector approaching zero. That is, each individual
+  ;; coordinate should be uniformly randomly distributed in the
+  ;; interval [-1,1]. The sum of REPS samples of these should
+  ;; converge to zero, within pi/2 sqrt(REPS).
   (define (converge-to-zero samples)
     (fold (lambda (acc sample) (vector-map + sample acc))
           (make-vector REPS 0.0)
@@ -76,20 +77,20 @@
     (define zz (norm-should-be-zero samples))
     (test-assert (< zz 1)))
 
-  ; maximum allowed tolerance for radius deviation
+  ;; maximum allowed tolerance for radius deviation
   (define EPS (* 2e-15 (sqrt N)))
 
-  ; Each individual sphere radius should be 1.0 to within float
-  ; tolerance.
+  ;; Each individual sphere radius should be 1.0 to within float
+  ;; tolerance.
   (for-each
     (lambda (SAMP)
       (test-approximate 1.0 (l2-norm SAMP) EPS))
     samples)
 
-  ; The distribution should be zero
+  ;; The distribution should be zero
   (check-zero samples)
 
-  ; Rotate wildly. Should still be uniform.
+  ;; Rotate wildly. Should still be uniform.
   (when rotate?
     (for-each
       (lambda (junk) (check-zero (arb-rot samples)))
@@ -133,3 +134,163 @@
   (test-ball-generates-on-radius 1.0 0.1)
 
   (test-ball-avg-zero 5000))
+
+  ;; Number of standard deviation difference from the expected value
+  ;; before we say a test failed.  If set to 2, then one out of
+  ;; 20 tests will fail even if the code is correct.  Setting it to
+  ;; 3 means that only one out of a 1000 tests will fail even if the
+  ;; code is correct.
+
+  (define STDs 3)
+
+  (define (test-ellipsoid a b N)
+
+    (define epsilon 1e-10)
+
+    (define pi (* 4 (atan 1)))
+
+    (define g (make-ellipsoid-generator (vector a b)))
+
+    (define points (generator->list (gtake g N)))
+
+    ;; The points on the "top" of the ellipse, with
+    ;; x between -a/2 and a/2
+
+    (define top
+      (filter (lambda (v)
+                (and (<  (- (/ a 2)) (vector-ref v 0) (/ a 2))
+                     (<  0 (vector-ref v 1))))
+              points))
+
+    ;; The points on the "right" of the ellipse, with
+    ;; y between -b/2 and b/2
+
+    (define right
+      (filter (lambda (v)
+                (and (< (- (/ b 2)) (vector-ref v 1) (/ b 2))
+                     (< 0 (vector-ref v 0))))
+              points))
+
+    (define (arc-length a b)
+      ;; parametrization: (a\cos t, b\sin t)
+      ;; this is the norm of the derivative
+      (lambda (t)
+        (sqrt (+ (square (* a (sin t)))
+                 (square (* b (cos t)))))))
+
+    (define (simpsons-rule f t0 t1 N)
+      ;; O(Delta^4) numerical integration
+      ;; integrate f between t0 and t1 with N intervals
+      (let* ((Delta (/ (- t1 t0) N))
+             (sum1 (do ((i 0 (fx+ i 1))
+                        (sum 0. (+ sum
+                                   (f (+ t0 (* i Delta)))
+                                   (f (+ t0 (* (fx+ i 1) Delta))))))
+                       ((fx= i N) sum)))
+             (sum2 (do ((i 0 (fx+ i 1))
+                        (sum 0. (+ sum (f (+ t0 (* (+ i 0.5) Delta))))))
+                       ((fx= i N) sum))))
+        (* Delta (/ (+ (* 4 sum2) sum1) 6))))
+
+    (define p-right
+      (/ (simpsons-rule (arc-length a b) (- (* pi 1/6)) (* pi 1/6) 100)
+         (simpsons-rule (arc-length a b) 0 (* pi 2) 100)))
+
+    (define p-top
+      (/ (simpsons-rule (arc-length a b) (* pi 1/3) (* pi 2/3) 100)
+         (simpsons-rule (arc-length a b) 0 (* pi 2) 100)))
+
+    ;; test that they're all more-or-less on the ellipse
+
+    (test-assert (every (lambda (p)
+                          (< (abs (- (sqrt (+ (square (/ (vector-ref p 0) a))
+                                              (square (/ (vector-ref p 1) b))))
+                                     1))
+                             epsilon))
+                        points))
+
+    (for-each (lambda (p m)
+                ;; p = probability of landing in arc, m = measured number
+                (test-assert (< (abs (- (* p N) m))
+                                (* STDs (sqrt (* N p (- 1 p)))))))
+              (list p-right p-top)
+              (map length (list right top)))
+    )
+
+  (define (test-ellipse a b N)
+
+    ;; This test with two-dimensional ellipses stands in for all
+    ;; dimensions, as the code to generate points is independent
+    ;; of dimension
+
+    (define pi (* 4 (atan 1)))
+
+    (define interior-points
+      (generator->list (gtake (make-ball-generator (vector a b)) N)))
+
+    (define (in-ellipse? point)
+      (< (+ (square (/ (vector-ref point 0) a))
+            (square (/ (vector-ref point 1) b)))
+         1))
+
+    ;; Find points inside rectangles inside various parts
+    ;; of the ellipse
+
+    (define center
+      (filter (lambda (v)
+                (and (< (- (/ a 4))
+                        (vector-ref v 0)
+                        (/ a 4))
+                     (< (- (/ b 4))
+                        (vector-ref v 1)
+                        (/ b 4))))
+              interior-points))
+
+    (define right-x
+      ;; (right-x b/4) is on the ellipse
+      (* a (sqrt 15/16)))
+
+    (define right
+      (filter (lambda (v)
+                (and (< (- right-x (/ a 2))
+                        (vector-ref v 0)
+                        right-x)
+                     (< (- (/ b 4))
+                        (vector-ref v 1)
+                        (/ b 4))))
+              interior-points))
+
+    (define top-y
+      ;; (a/4 top-y) is on the ellipse
+      (* b (sqrt 15/16)))
+
+    (define top
+      (filter (lambda (v)
+                (and (< (- (/ a 4))
+                        (vector-ref v 0)
+                        (/ a 4))
+                     (< (- top-y (/ b 2))
+                        (vector-ref v 1)
+                        top-y)))
+              interior-points))
+
+    ;; p is he fraction of the area in the ellipse
+    ;; contained in the rectangles (it's all the same).
+
+    #;(define p
+    (/ (* (/ a 2) (/ b 2))
+    (* pi a b)))
+
+    (define p (/ (* 4 pi)))
+
+    ;; check that all the points are truly inside the ellipse.
+
+    (test-assert (every in-ellipse? interior-points))
+
+    (for-each (lambda (p m)
+                ;; p = probability of landing in rectangle,
+                ;; m = measured number of events
+                (test-assert (< (abs (- (* p N) m))
+                                (* STDs (sqrt (* N p (- 1 p)))))))
+              (list p p p)
+              (map length (list center right top))))

--- a/srfi/194.sld
+++ b/srfi/194.sld
@@ -11,7 +11,7 @@
    (else
     (import (scheme base)
             (srfi 133))))
-
+  
   (import (scheme case-lambda)
           (scheme inexact)
           (scheme complex)

--- a/zipf-test.scm
+++ b/zipf-test.scm
@@ -64,7 +64,11 @@
 
   ; Sequence 1..NVOCAB
   (define seq
-    (vector-unfold (lambda (i x) (values x (+ x 1))) NVOCAB 1))
+    (cond-expand
+     (gambit
+      (list->vector (iota NVOCAB 1)))
+     (else
+      (vector-unfold (lambda (i x) (values x (+ x 1))) NVOCAB 1))))
 
   ; Sequence  1/(k+QUE)^ESS
   (define inv-pow (vector-map


### PR DESCRIPTION
 Rework ball and ellipsoid generators, add tests

sphere-test.scm:

1.  Add Lucier copyright.
2.  Adjust formatting of comments.
3.  Add new tests for generation of points in interior and on border of two-dimensional ellipses.

srfi-194-test.scm

1.  Add Lucier copyright
2.  Adapt to work with (very) recent Gambits.
3.  Adjust formatting of comments.
4.  Execute new tests for generation of points on boundary and in interior of ellipses.

srfi/194.scm:

1.  Adapt for Gambit.

srfi/194.sld:

1.  New file.

srfi/sphere.scm

1.  Add Lucier copyright.
2.  Rewrite generators.

zipf-test.scm

1.  Adapt for Gambit.